### PR TITLE
Ask to create unreleased changelog directory if it doesn't exist

### DIFF
--- a/Sources/ChangelogCore/Commands/Publish.swift
+++ b/Sources/ChangelogCore/Commands/Publish.swift
@@ -48,6 +48,7 @@ struct Publish: ParsableCommand {
     }
     
     private var fileManager: FileManager = .default
+    var outputController: OutputControlling = OutputController()
     
     enum CodingKeys: String, CodingKey {
         case options, version, releaseDate, dryRun, changelogFilename, changelogHeaderFileURL
@@ -73,13 +74,13 @@ struct Publish: ParsableCommand {
         
         if dryRun {
             let entryNoun = changelogFilePaths.count == 1 ? "entry" : "entries"
-            OutputController.write("\n(Dry run) would have deleted \(changelogFilePaths.count) unreleased changelog \(entryNoun).", inColor: .yellow)
+            outputController.write("\n(Dry run) would have deleted \(changelogFilePaths.count) unreleased changelog \(entryNoun).", inColor: .yellow)
             return
         }
         
         try record(groupedEntries: groupedEntries, changelogFilePaths: changelogFilePaths)
         
-        OutputController.write("\nNice! \(changelogFilename) was updated. Congrats on the release! 🥳🍻", inColor: .green)
+        outputController.write("\nNice! \(changelogFilename) was updated. Congrats on the release! 🥳🍻", inColor: .green)
     }
     
     private func printChangelogSummary(groupedEntries: [EntryType: [ChangelogEntry]], changelogFilePaths: [URL]) {
@@ -91,7 +92,7 @@ struct Publish: ParsableCommand {
             }
         })
         
-        OutputController.write(
+        outputController.write(
             """
 
             ## [\(version)] - \(releaseDate)
@@ -147,7 +148,7 @@ struct Publish: ParsableCommand {
     
     private func writeHeaderIfNeeded(to changelog: FileHandle) {
         guard let header = try? String(contentsOf: changelogHeaderFileURL) else {
-            OutputController.write("No changelog header was found; skipping...")
+            outputController.write("No changelog header was found; skipping...")
             return
         }
         

--- a/Sources/ChangelogCore/Errors.swift
+++ b/Sources/ChangelogCore/Errors.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 enum ChangelogError: LocalizedError, Equatable {
+    case changelogDirectoryNotFound(expectedPath: String)
     case malformattedEntry(atPath: String)
     case noEntriesFound
     case noTextEntered
@@ -16,6 +17,8 @@ enum ChangelogError: LocalizedError, Equatable {
     
     var errorDescription: String? {
         switch self {
+        case .changelogDirectoryNotFound(let expectedPath):
+            return "Couldn't find the changelog directory. Please check that `\(expectedPath)` exists and is readable from your current working directory."
         case .malformattedEntry(let path):
             return "The changelog entry at \(path) is malformatted. Please fix or remove the file and try again."
         case .noEntriesFound:

--- a/Sources/ChangelogCore/Errors.swift
+++ b/Sources/ChangelogCore/Errors.swift
@@ -8,7 +8,6 @@
 import Foundation
 
 enum ChangelogError: LocalizedError, Equatable {
-    case changelogDirectoryNotFound(expectedPath: String)
     case malformattedEntry(atPath: String)
     case noEntriesFound
     case noTextEntered
@@ -17,8 +16,6 @@ enum ChangelogError: LocalizedError, Equatable {
     
     var errorDescription: String? {
         switch self {
-        case .changelogDirectoryNotFound(let expectedPath):
-            return "Couldn't find the changelog directory. Please check that `\(expectedPath)` exists and is readable from your current working directory."
         case .malformattedEntry(let path):
             return "The changelog entry at \(path) is malformatted. Please fix or remove the file and try again."
         case .noEntriesFound:

--- a/Sources/ChangelogCore/FileManaging.swift
+++ b/Sources/ChangelogCore/FileManaging.swift
@@ -1,0 +1,25 @@
+//
+//  FileManaging.swift
+//  
+//
+//  Created by Patrick Gatewood on 1/20/22.
+//
+
+import Foundation
+
+protocol FileManaging {
+    func removeItem(at URL: URL) throws
+    func fileExists(atPath path: String) -> Bool
+    func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]?
+    ) throws
+    func contentsOfDirectory(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions
+    ) throws -> [URL]
+}
+
+extension FileManager: FileManaging { }

--- a/Sources/ChangelogCore/OutputController.swift
+++ b/Sources/ChangelogCore/OutputController.swift
@@ -8,8 +8,19 @@
 import Foundation
 import TSCBasic
 
-enum OutputController {
-    static func write(_ text: String, inColor color: TerminalController.Color = .noColor) {
+protocol OutputControlling {
+    func write(_ text: String, inColor color: TerminalController.Color)
+    func tryWrap(_ text: String, inColor color: TerminalController.Color, bold: Bool) -> String
+}
+
+extension OutputControlling {
+    func write(_ text: String) {
+        write(text, inColor: .noColor)
+    }
+}
+
+struct OutputController: OutputControlling {
+    func write(_ text: String, inColor color: TerminalController.Color) {
         guard let outTerminalController = TerminalController(stream: stdoutStream) else {
             print(text)
             return
@@ -18,7 +29,7 @@ enum OutputController {
         outTerminalController.write(text, inColor: color)
     }
     
-    static func tryWrap(_ text: String, inColor color: TerminalController.Color, bold: Bool) -> String {
+    func tryWrap(_ text: String, inColor color: TerminalController.Color, bold: Bool) -> String {
         guard let outTerminalController = TerminalController(stream: stdoutStream) else {
             return text
         }

--- a/Sources/ChangelogCore/Prompt.swift
+++ b/Sources/ChangelogCore/Prompt.swift
@@ -19,7 +19,7 @@ struct Prompt: PromptProtocol {
         var userInput: String?
         
         repeat {
-            outputController.write(prompt)
+            outputController.write("\(prompt)\n")
             userInput = readLine()
         } while userInput == nil
         

--- a/Sources/ChangelogCore/Prompt.swift
+++ b/Sources/ChangelogCore/Prompt.swift
@@ -1,0 +1,36 @@
+//
+//  Prompt.swift
+//  
+//
+//  Created by Patrick Gatewood on 1/20/22.
+//
+
+import Foundation
+import ArgumentParser
+
+protocol PromptProtocol {
+    func promptUser<ParsableType: ParsableArguments>(with prompt: String) throws -> ParsableType
+}
+
+struct Prompt: PromptProtocol {
+    let outputController: OutputControlling
+    
+    func promptUser<ParsableType: ParsableArguments>(with prompt: String) throws -> ParsableType {
+        var userInput: String?
+        
+        repeat {
+            outputController.write(prompt)
+            userInput = readLine()
+        } while userInput == nil
+        
+        return try ParsableType.parse([userInput!])
+    }
+}
+
+struct Confirmation: ParsableArguments {
+    @Argument(transform: boolValue) var value: Bool
+    
+    private static func boolValue(of string: String) throws -> Bool {
+        (string as NSString).boolValue
+    }
+}

--- a/Tests/changelog-generatorTests/LogCommandTests.swift
+++ b/Tests/changelog-generatorTests/LogCommandTests.swift
@@ -10,21 +10,6 @@ import TSCBasic
 @testable import ChangelogCore
 
 class LogCommandTests: XCTestCase {
-    func test_givenNoChangelogDirectory_thenLogThrowsError() {
-        var logCommand = Log()
-        logCommand.entryType = .change
-        logCommand.text = ["Test entry"]
-        logCommand.options = Changelog.Options(unreleasedChangelogsDirectory: Changelog.Options.defaultUnreleasedChangelogDirectory)
-        
-        XCTAssertThrowsError(try logCommand.run()) { error in
-            guard let changelogError = error as? ChangelogError,
-                  case .changelogDirectoryNotFound(_) = changelogError else {
-                XCTFail("Expected ChangelogError.changelogDirectoryNotFound to be thrown")
-                return
-            }
-        }
-    }
-    
     func test_givenAdditionOption_whenTextIsValid_thenTextIsWrittenToDisk() throws {
         let sampleAdditionText = "Added an additive ability to add additions"
         

--- a/Tests/changelog-generatorTests/LogCommandTests.swift
+++ b/Tests/changelog-generatorTests/LogCommandTests.swift
@@ -138,5 +138,16 @@ class LogCommandTests: XCTestCase {
             XCTAssertEqual(entry.text, formattedSampleText)
         }
     }
-    
+}
+
+/// https://github.com/apple/swift-argument-parser/issues/359#issuecomment-991336822
+private extension Log {
+    init(
+        fileManager: FileManaging,
+        prompt: PromptProtocol
+    ) {
+        self.init()
+        self.fileManager = fileManager
+        self.prompt = prompt
+    }
 }

--- a/Tests/changelog-generatorTests/Mocks/MockFileManager.swift
+++ b/Tests/changelog-generatorTests/Mocks/MockFileManager.swift
@@ -1,0 +1,44 @@
+//
+//  MockFileManager.swift
+//  
+//
+//  Created by Patrick Gatewood on 1/20/22.
+//
+
+import Foundation
+@testable import ChangelogCore
+
+struct MockFileManager: FileManaging {
+    var removeItemHook: ((URL) throws -> Void ) = { _ in }
+    var fileExistsHook: ((String) -> Bool) = { _ in true }
+    var createDirectoryHook: ((URL, Bool, [FileAttributeKey: Any]?) throws -> Void) = { _, _, _ in }
+    var contentsOfDirectoryHook: (
+        (URL, [URLResourceKey]?, FileManager.DirectoryEnumerationOptions) throws -> [URL]
+    ) = { _, _, _ in
+        return []
+    }
+    
+    func removeItem(at URL: URL) throws {
+        try removeItemHook(URL)
+    }
+    
+    func fileExists(atPath path: String) -> Bool {
+        fileExistsHook(path)
+    }
+    
+    func createDirectory(
+        at url: URL,
+        withIntermediateDirectories createIntermediates: Bool,
+        attributes: [FileAttributeKey: Any]?
+    ) throws {
+        try createDirectoryHook(url, createIntermediates, attributes)
+    }
+    
+    func contentsOfDirectory(
+        at url: URL,
+        includingPropertiesForKeys keys: [URLResourceKey]?,
+        options mask: FileManager.DirectoryEnumerationOptions
+    ) throws -> [URL] {
+        try contentsOfDirectoryHook(url, keys, mask)
+    }
+}

--- a/Tests/changelog-generatorTests/Mocks/MockPrompt.swift
+++ b/Tests/changelog-generatorTests/Mocks/MockPrompt.swift
@@ -1,0 +1,19 @@
+//
+//  MockPrompt.swift
+//  
+//
+//  Created by Patrick Gatewood on 1/20/22.
+//
+
+import ArgumentParser
+@testable import ChangelogCore
+import XCTest
+
+struct MockPrompt<ParsableType: ParsableArguments>: PromptProtocol {
+    var mockPromptResponse: ParsableType?
+    
+    func promptUser<ParsableType: ParsableArguments>(with prompt: String) throws -> ParsableType {
+        let response = mockPromptResponse as? ParsableType
+        return try XCTUnwrap(response)
+    }
+}

--- a/changelogs/unreleased/1A465875-F94A-40D4-B5ED-C7E34969F68E-15465-0004956FD96959AD.md
+++ b/changelogs/unreleased/1A465875-F94A-40D4-B5ED-C7E34969F68E-15465-0004956FD96959AD.md
@@ -1,0 +1,2 @@
+### Added
+- [Ask to create default files if they don't exist](https://github.com/pg8wood/changelog-generator/issues/1)

--- a/changelogs/unreleased/670FB68C-64C2-4C8C-8420-79520533ADAD-15636-00049574B557CF33.md
+++ b/changelogs/unreleased/670FB68C-64C2-4C8C-8420-79520533ADAD-15636-00049574B557CF33.md
@@ -1,0 +1,2 @@
+### Fixed
+- [`changelogs/unreleased` directory is removed by git after publishing a release](https://github.com/pg8wood/changelog-generator/issues/3)


### PR DESCRIPTION
Closes #1 and #3

To test manually: 
```sh
swift run changelog -d fakeDirectoryName add "hello, world"
```
...assuming you don't have a directory called `fakeDirectoryName` in your working directory 😉 